### PR TITLE
Dragon Master Knight (Anime)

### DIFF
--- a/Scripts/c111000001.lua
+++ b/Scripts/c111000001.lua
@@ -1,0 +1,28 @@
+--Dragon Master Knight (Anime)
+--script by: mbcn10ww (The Master)
+function c111000001.initial_effect(c)
+	--fusion material
+	c:EnableReviveLimit()
+	aux.AddFusionProcCode2(c,5405694,23995346,true,true)
+	--spsummon condition
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(aux.fuslimit)
+	c:RegisterEffect(e1)
+	--atk
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetValue(c111000001.atkval)
+	c:RegisterEffect(e2)
+end
+function c111000001.filter(c)
+	return c:IsFaceup() and c:IsRace(RACE_DRAGON)
+end
+function c111000001.atkval(e,c)
+	return Duel.GetMatchingGroupCount(c111000001.filter,c:GetControler(),LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,c)*500
+end


### PR DESCRIPTION
"Black Luster Soldier" + "Blue-Eyes Ultimate Dragon"
This monster cannot be Special Summoned except by Fusion Summon. This card gains 500 ATK for each Dragon-Type monster on the field and in the Graveyard.
