### PR TITLE
Blue-Eyes Shining Dragon (Anime)

### DIFF
--- a/Scripts/c111000002.lua
+++ b/Scripts/c111000002.lua
@@ -1,0 +1,97 @@
+--Blue-Eyes Shining Dragon (Anime)
+--script by: mbcn10ww (The Master)
+function c111000002.initial_effect(c)
+	c:EnableReviveLimit()
+	--Cannot Special Summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(aux.FALSE)
+	c:RegisterEffect(e1)
+	--Special Summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c111000002.spcon)
+	e2:SetOperation(c111000002.spop)
+	c:RegisterEffect(e2)
+	--Shining Burst
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e3:SetCode(EFFECT_UPDATE_ATTACK)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetValue(c111000002.sbval)
+	c:RegisterEffect(e3)
+	--Shining Diffusion
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(111000002,0))
+	e4:SetCategory(CATEGORY_DISABLE)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_QUICK_O)
+	e4:SetCode(EVENT_CHAINING)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCondition(c111000002.sdcon)
+	e4:SetTarget(c111000002.sdtg)
+	e4:SetOperation(c111000002.sdop)
+	c:RegisterEffect(e4)
+	--Shining Nova
+	local e5=Effect.CreateEffect(c)
+	e5:SetCategory(CATEGORY_DESTROY)
+	e5:SetType(EFFECT_TYPE_IGNITION)
+	e5:SetCode(EVENT_FREE_CHAIN)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetCost(c111000002.sncost)
+	e5:SetTarget(c111000002.sntg)
+	e5:SetOperation(c111000002.snop)
+	c:RegisterEffect(e5)
+end
+function c111000002.spcon(e,c)
+	if c==nil then return true end
+	return Duel.CheckReleaseGroup(c:GetControler(),Card.IsCode,1,nil,23995346)
+end
+function c111000002.spop(e,tp,eg,ep,ev,re,r,rp,c)
+	local g=Duel.SelectReleaseGroup(c:GetControler(),Card.IsCode,1,1,nil,23995346)
+	Duel.Release(g,REASON_COST)
+end
+function c111000002.sbval(e,c)
+	return Duel.GetMatchingGroupCount(Card.IsRace,c:GetControler(),LOCATION_GRAVE,0,nil,RACE_DRAGON)*300
+end
+function c111000002.sdcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsStatus(STATUS_BATTLE_DESTROYED) then return false end
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return end
+	local loc,tg=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TARGET_CARDS)
+	if not tg or not tg:IsContains(c) then return false end
+	return Duel.IsChainDisablable(ev) and loc~=LOCATION_DECK
+end
+function c111000002.sdtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
+end
+function c111000002.sdop(e,tp,eg,ep,ev,re,r,rp,chk)
+	Duel.NegateEffect(ev)
+end
+--Shining Nova
+function c111000002.sncost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsReleasable() end
+	Duel.Release(e:GetHandler(),REASON_COST)
+end
+function c111000002.snfilter(c)
+	return c:IsDestructable() --and c:IsType(TYPE_SPELL+TYPE_TRAP+TYPE_MONSTER)
+end
+function c111000002.sntg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and c111000002.snfilter(chkc) and chkc~=e:GetHandler() end
+	if chk==0 then return Duel.IsExistingTarget(c111000002.snfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c111000002.snfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c111000002.snop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end


### PR DESCRIPTION
This card cannot be Normal Summoned or Set. This card cannot be Special Summoned from your hand except by offering 1 "Blue-Eyes Ultimate Dragon" on your side of the field as a Tribute. (Special Attack Name: Shining Burst) Increase the ATK of this card by 300 points for each Dragon-Type monster in your Graveyard. (Special Effect 1 mechanical name: Shining Diffusion) You can negate the effect of Spell, Trap and Monster Cards that designate this card. (Special Effect 2 mechanical name: Shining Nova) You can offer this card as a Tribute to destroy any cards you designate.
