### PR TITLE
c511001372 - Number c88 - gimmick puppet disaster leo (anime)

### DIFF
--- a/Scripts/c511001372.lua
+++ b/Scripts/c511001372.lua
@@ -1,9 +1,9 @@
---CNo.88 ギミック・パペット－ディザスター・レオ
+--Number C88: Gimmick Puppet Disaster Leo (Anime)
 function c511001372.initial_effect(c)
 	--xyz summon
 	aux.AddXyzProcedure(c,nil,9,4)
 	c:EnableReviveLimit()
-	--
+	--immunity
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
@@ -34,6 +34,32 @@ function c511001372.initial_effect(c)
 	e4:SetCondition(c511001372.con)
 	e4:SetOperation(c511001372.winop)
 	c:RegisterEffect(e4)
+	if not c511001372.global_check then
+		c511001372.global_check=true
+		local ge2=Effect.CreateEffect(c)
+		ge2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge2:SetCode(EVENT_ADJUST)
+		ge2:SetCountLimit(1)
+		ge2:SetProperty(EFFECT_FLAG_NO_TURN_RESET)
+		ge2:SetOperation(c511001372.numchk)
+		Duel.RegisterEffect(ge2,0)
+	end
+	--battle indestructable
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+	e5:SetValue(c511001372.indes)
+	c:RegisterEffect(e5)
+	if not c511001372.global_check then
+		c511001372.global_check=true
+		local ge5=Effect.CreateEffect(c)
+		ge5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge5:SetCode(EVENT_ADJUST)
+		ge5:SetCountLimit(1)
+		ge5:SetProperty(EFFECT_FLAG_NO_TURN_RESET)
+		ge5:SetOperation(c511001372.numchk)
+		Duel.RegisterEffect(ge5,0)
+	end
 end
 c511001372.xyz_number=88
 function c511001372.efilter(e,te)
@@ -49,8 +75,8 @@ end
 function c511001372.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetTargetPlayer(1-tp)
-	Duel.SetTargetParam(2000)
-	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,2000)
+	Duel.SetTargetParam(4000)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,4000)
 end
 function c511001372.operation(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
@@ -64,4 +90,11 @@ function c511001372.winop(e,tp,eg,ep,ev,re,r,rp)
 		local WIN_REASON_DISASTER_LEO=0x18
 		Duel.Win(tp,WIN_REASON_DISASTER_LEO)
 	end
+end
+function c511001372.numchk(e,tp,eg,ep,ev,re,r,rp)
+	Duel.CreateToken(tp,6165656)
+	Duel.CreateToken(1-tp,6165656)
+end
+function c511001372.indes(e,c)
+	return not c:IsSetCard(0x48)
 end


### PR DESCRIPTION
It was missing the anime number's battle clause and the damage dealt by its effect should be 4000 and not 2000 like in the anime.
