### PR TITLE
Update c100000198.lua

### DIFF
--- a/Scripts/c100000198.lua
+++ b/Scripts/c100000198.lua
@@ -59,4 +59,6 @@ function c100000198.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
 		tc:RegisterEffect(e1)
 	end
+	
+	~~~
 end


### PR DESCRIPTION
Card Name :Attribute Chameleon

This Card Effect : Once during your opponent's turn, you can select 1 face-up monster your opponent controls and declare 1 Attribute. That monster's Attribute becomes the declared Attribute until the End Phase.

In The YGOPRO :  it has the same effect (( But )) the problem  when you activate it on the field it does not work at all and the script down below keep saying error 

So Please help I cannot right a script and what should i do to make it work 

Thanks
